### PR TITLE
Setup Solidus_oxxo_pay gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -81,6 +81,7 @@ gem "canonical-rails"
 gem "solidus_support"
 gem "truncate_html"
 gem "view_component", "~> 2.46"
+gem 'solidus_oxxo_pay', github: 'magma-labs/solidus_oxxo_pay'
 
 group :development, :test do
   gem "rspec-rails"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,4 +1,14 @@
 GIT
+  remote: https://github.com/magma-labs/solidus_oxxo_pay.git
+  revision: 97db9931aad227553e8a6a929bcf9750d676782f
+  specs:
+    solidus_oxxo_pay (1.1.0)
+      conekta
+      deface (~> 1.0)
+      solidus_core (>= 2.6, < 4)
+      solidus_support (~> 0.5)
+
+GIT
   remote: https://github.com/twalpole/apparition.git
   revision: ca86be4d54af835d531dbcd2b86e7b2c77f85f34
   specs:
@@ -134,6 +144,12 @@ GEM
     codecov (0.6.0)
       simplecov (>= 0.15, < 0.22)
     concurrent-ruby (1.1.10)
+    conekta (2.5.0)
+      bundler (>= 1.3)
+      faraday
+      json
+      rake
+      sys-uname
     console (1.15.3)
       fiber-local
     crass (1.0.6)
@@ -500,6 +516,8 @@ GEM
       railties (>= 6.0.0)
     stringio (3.0.2)
     strscan (3.0.4)
+    sys-uname (1.2.2)
+      ffi (~> 1.1)
     terrapin (0.6.0)
       climate_control (>= 0.0.3, < 1.0)
     thor (1.2.1)
@@ -561,6 +579,7 @@ DEPENDENCIES
   solidus_backend (~> 3.2)
   solidus_core (~> 3.2)
   solidus_dev_support (~> 2.5)
+  solidus_oxxo_pay!
   solidus_sample (~> 3.2)
   solidus_support
   sprockets-rails

--- a/app/assets/config/manifest.js
+++ b/app/assets/config/manifest.js
@@ -2,3 +2,4 @@
 //= link_directory ../stylesheets .css
 //= link_tree ../../javascript .js
 //= link_tree ../../../vendor/javascript .js
+//= link spree/frontend/all.css

--- a/db/migrate/20220830200612_create_conekta_oxxo_payments.solidus_oxxo_pay.rb
+++ b/db/migrate/20220830200612_create_conekta_oxxo_payments.solidus_oxxo_pay.rb
@@ -1,0 +1,15 @@
+# frozen_string_literal: true
+
+# This migration comes from solidus_oxxo_pay (originally 20181121200357)
+class CreateConektaOxxoPayments < ActiveRecord::Migration[5.0]
+  def change
+    create_table :spree_conekta_oxxo_payments do |t|
+      t.references :payment_method
+      t.string :number
+      t.string :conekta_order_id
+      t.string :first_name
+      t.string :last_name
+      t.integer :user_id
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.0].define(version: 2022_08_30_193785) do
+ActiveRecord::Schema[7.0].define(version: 2022_08_30_200612) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -174,6 +174,16 @@ ActiveRecord::Schema[7.0].define(version: 2022_08_30_193785) do
     t.index ["imported_from_shipment_id"], name: "index_spree_cartons_on_imported_from_shipment_id", unique: true
     t.index ["number"], name: "index_spree_cartons_on_number", unique: true
     t.index ["stock_location_id"], name: "index_spree_cartons_on_stock_location_id"
+  end
+
+  create_table "spree_conekta_oxxo_payments", id: :serial, force: :cascade do |t|
+    t.integer "payment_method_id"
+    t.string "number"
+    t.string "conekta_order_id"
+    t.string "first_name"
+    t.string "last_name"
+    t.integer "user_id"
+    t.index ["payment_method_id"], name: "index_spree_conekta_oxxo_payments_on_payment_method_id"
   end
 
   create_table "spree_countries", id: :serial, force: :cascade do |t|

--- a/vendor/assets/javascripts/spree/backend/all.js
+++ b/vendor/assets/javascripts/spree/backend/all.js
@@ -8,3 +8,4 @@
 //= require rails-ujs
 //= require spree/backend
 //= require_tree .
+//= require spree/backend/solidus_oxxo_pay

--- a/vendor/assets/javascripts/spree/frontend/all.js
+++ b/vendor/assets/javascripts/spree/frontend/all.js
@@ -7,3 +7,4 @@
 //= require rails-ujs
 //= require spree/frontend
 //= require_tree .
+//= require spree/frontend/solidus_oxxo_pay

--- a/vendor/assets/stylesheets/spree/backend/all.css
+++ b/vendor/assets/stylesheets/spree/backend/all.css
@@ -6,4 +6,5 @@
  *= require spree/backend
  *= require_self
  *= require_tree .
+ *= require spree/backend/solidus_oxxo_pay
 */

--- a/vendor/assets/stylesheets/spree/frontend/all.css
+++ b/vendor/assets/stylesheets/spree/frontend/all.css
@@ -6,4 +6,5 @@
  *= require spree/frontend
  *= require_self
  *= require_tree .
+ *= require spree/frontend/solidus_oxxo_pay
 */


### PR DESCRIPTION
### Quick Info
- Add `solidus_oxxo_pay`  gem extension.

### What does this change?
- Add the functionality to process payments through conekta oxxo.

### Why are you changing that?
- Becausea are necessary 

### How did you accomplish this change?
- Through the [magmalabs extension](https://github.com/magma-labs/solidus_oxxo_pay)

### Screenshots

#### Desktop
![image](https://user-images.githubusercontent.com/50384228/187567156-3014b40a-00ae-4ac5-b4bb-d2af6448af9c.png)
